### PR TITLE
Add auth_method referring to embulk-input-google_spreadsheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /.bundle/
 /Gemfile.lock
 /vendor/
+
+authorized_user_credentials.json

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org/'
 gemspec
+
+gem "highline"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Dumps records to Google Sheets.
 
 - if `auth_method` is `service_account`, set the service account credential json file path.
 - if `auth_method` is `authorized_user`, this plugin supposes the format is the below.
+  https://github.com/medjed/embulk-input-google_spreadsheets#prepare-json-file-for-auth_method-authorized_user
 
 ```json
 {
@@ -29,6 +30,19 @@ Dumps records to Google Sheets.
   "client_secret": "xxxxxxxxxxx",
   "refresh_token": "xxxxxxxxxxx"
 }
+```
+
+## Prepare JSON file for auth_method: authorized_user
+
+You may use [example/setup_authorized_user_credentials.rb](example/setup_authorized_user_credentials.rb) to prepare OAuth token.
+
+Go to GCP console > API Manager > Credentials > Create 'OAuth Client ID'. Get the client id and client secret.
+
+Run `setup_authorized_user_credentials.rb` to get `refresh_token`.
+
+```
+bundle --path vendor/bundle
+bundle exec ruby example/setup_authorized_user_credentials.rb
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -4,15 +4,32 @@ Dumps records to Google Sheets.
 
 ## Overview
 
-* **Plugin type**: output
-* **Load all or nothing**: yes
-* **Resume supported**: no
-* **Cleanup supported**: no
+- **Plugin type**: output
+- **Load all or nothing**: yes
+- **Resume supported**: no
+- **Cleanup supported**: no
 
 ## Configuration
 
-- **spreadsheet_id**: Spreadsheet ID (string, required)
-- **credentials_path**: Credentials JSON path (string, default: `"credentials.json"`)
+| name             | type   | requirement | default              | description                            |
+| :--------------- | :----- | :---------- | :------------------- | :------------------------------------- |
+| spreadsheet_id   | string | required    |                      |                                        |
+| credentials_path | string | optional    | `"credentials.json"` | keyfile path                           |
+| range            | string | optional    | `"A1"`               |                                        |
+| auth_method      | string | optional    | `service_account`    | `service_account` or `authorized_user` |
+
+##### about credentials_path
+
+- if `auth_method` is `service_account`, set the service account credential json file path.
+- if `auth_method` is `authorized_user`, this plugin supposes the format is the below.
+
+```json
+{
+  "client_id": "xxxxxxxxxxx.apps.googleusercontent.com",
+  "client_secret": "xxxxxxxxxxx",
+  "refresh_token": "xxxxxxxxxxx"
+}
+```
 
 ## Example
 
@@ -24,6 +41,18 @@ out:
   range: A1
 ```
 
+## Prepare JSON file for auth_method: authorized_user
+
+You may use [example/setup_authorized_user_credentials.rb](example/setup_authorized_user_credentials.rb) to prepare OAuth token.
+
+Go to GCP console > API Manager > Credentials > Create 'OAuth Client ID'. Get the client id and client secret.
+
+Run `setup_authorized_user_credentials.rb` to get `refresh_token`.
+
+```
+bundle --path vendor/bundle
+bundle exec ruby example/setup_authorized_user_credentials.rb
+```
 
 ## Build
 

--- a/embulk-output-google_sheets_ruby.gemspec
+++ b/embulk-output-google_sheets_ruby.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'embulk-output-google_sheets_ruby'
-  spec.version       = '0.1.0'
+  spec.version       = '0.1.1'
   spec.authors       = ['ariarijp']
   spec.summary       = 'Google Sheets Ruby output plugin for Embulk'
   spec.description   = 'Dumps records to Google Sheets.'

--- a/example/setup_authorized_user_credentials.rb
+++ b/example/setup_authorized_user_credentials.rb
@@ -1,0 +1,34 @@
+require 'googleauth'
+require 'google/apis/sheets_v4'
+require 'highline/import'
+require 'json'
+
+puts 'Before setup, open this page https://developers.google.com/identity/protocols/OAuth2'
+puts 'then get OAuth 2.0 credentials such as a client ID and client secret according to the above page.'
+puts
+
+credentials = Google::Auth::UserRefreshCredentials.new(
+  client_id: ask('Enter client_id: '),
+  client_secret: ask('Enter client_secret: '),
+  scope: Google::Apis::SheetsV4::AUTH_SPREADSHEETS,
+  redirect_uri: 'urn:ietf:wg:oauth:2.0:oob'
+)
+
+credentials.code = ask(
+  "1. Open this page '#{credentials.authorization_uri.to_s}'.\n" \
+  '2. Enter the authorization code shown in the page: '
+) {|q| q.echo = false}
+
+credentials.fetch_access_token!
+
+data = {
+  client_id: credentials.client_id,
+  client_secret: credentials.client_secret,
+  refresh_token: credentials.refresh_token,
+}.to_json
+file = File.expand_path('authorized_user_credentials.json', __dir__)
+File.open(file, 'w') do |f|
+  f.write(data)
+end
+
+puts "Success. See '#{file}'."


### PR DESCRIPTION
- base is [medjed/embulk\-input\-google\_spreadsheets](https://github.com/medjed/embulk-input-google_spreadsheets)
- add `auth_method` options and `authorized_user` param
- add setup credential script. scope is not readonly
- edit README

plz review.

--------------------- ja

- [medjed/embulk\-input\-google\_spreadsheets](https://github.com/medjed/embulk-input-google_spreadsheets) にあった `authorized_user` の認証を使いたかったので修正しました
- `auth_method` というオプションを追加して `authorized_user` というモードを追加しました
- credentialファイルを作成するスクリプトを追加しました。scopeはREADONLYではないものにしています
- 合わせてREADMEを編集しました

レビューお願いします。